### PR TITLE
Use drools-verifier to analyze rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea/
+/target/

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,19 @@
             <version>0.0.1-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.24.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,12 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.4.8</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-verifier-drl</artifactId>
+            <version>${drools.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.emla</groupId>
             <artifactId>emla</artifactId>
             <version>0.0.1-SNAPSHOT</version>

--- a/src/main/java/org/nprentza/Agent.java
+++ b/src/main/java/org/nprentza/Agent.java
@@ -2,11 +2,16 @@ package org.nprentza;
 
 public class Agent {
     private int id;
-    private String role;    // admin, guest
+    private AgentRole role;    // admin, guest
     private String experience;
     private boolean grantAccess;
 
-    public Agent(int id, String role, String experience){
+    public static Agent fromRawData(int id, String role, String experience){
+        AgentRole agentRole = AgentRole.valueOf(role.toUpperCase());
+        return new Agent(id, agentRole, experience);
+    }
+
+    private Agent(int id, AgentRole role, String experience){
         this.id = id;
         this.role = role;
         this.experience = experience;
@@ -14,8 +19,8 @@ public class Agent {
 
     public int getId(){return this.id;}
 
-    public void setRole(String role){this.role=role;}
-    public String getRole(){return this.role;}
+    public void setRole(AgentRole role){this.role=role;}
+    public AgentRole getRole(){return this.role;}
 
     public void setExperience(String experience) {this.experience = experience;}
     public String getExperience(){return this.experience;}

--- a/src/main/java/org/nprentza/AgentRole.java
+++ b/src/main/java/org/nprentza/AgentRole.java
@@ -1,0 +1,7 @@
+package org.nprentza;
+
+public enum AgentRole {
+    ADMIN,
+    CONTRIBUTOR,
+    GUEST
+}

--- a/src/main/java/org/nprentza/DrlConverter.java
+++ b/src/main/java/org/nprentza/DrlConverter.java
@@ -1,0 +1,49 @@
+package org.nprentza;
+
+import org.emla.learning.Frequency;
+
+public final class DrlConverter {
+
+    private DrlConverter() {
+    }
+
+    public static String frequencyToDrlRule(Frequency frequency) {
+        String field = frequency.getPredictorValues().getLeft();
+        String value = frequency.getPredictorValues().getRight().toString();
+        String decision = frequency.getBestTargetValue();
+        String ruleName = decision + value;
+
+        return rule(ruleName, field, value, decision);
+    }
+
+    public static String preamble() {
+        return "package org.nprentza;\n" +
+                "\n" +
+                "import " + Agent.class.getCanonicalName() + ";\n" +
+                "import " + AgentRole.class.getCanonicalName() + ";\n" +
+                "\n" +
+                "global java.util.List allow;\n" +
+                "global java.util.List deny;\n" +
+                "\n";
+    }
+
+    public static String rule(String ruleName, String field, String value, String decision) {
+        return "rule '" + ruleName + "' when\n" +
+                "  $a: Agent( " + equalityCheck(field, value) + " ) \n" +
+                "then\n" +
+                "  $a.setGrantAccess( " + grantAccess(decision) + " );\n" +
+                "  " + decision + ".add( $a.getId() );\n" +
+                "end\n";
+    }
+
+    private static String equalityCheck(String field, String value) {
+        if (field.equals("role")) {
+            return "role == " + AgentRole.class.getSimpleName() + "." + AgentRole.valueOf(value.toUpperCase()).name();
+        }
+        return field + " == " + value;
+    }
+
+    private static boolean grantAccess(String decision) {
+        return decision.equals("allow");
+    }
+}

--- a/src/main/java/org/nprentza/DroolsAgentApp.java
+++ b/src/main/java/org/nprentza/DroolsAgentApp.java
@@ -1,5 +1,12 @@
 package org.nprentza;
 
+import org.drools.io.ReaderResource;
+import org.drools.verifier.Verifier;
+import org.drools.verifier.builder.VerifierBuilderFactory;
+import org.drools.verifier.data.VerifierReport;
+import org.drools.verifier.report.components.MissingRange;
+import org.drools.verifier.report.components.Severity;
+import org.drools.verifier.report.components.VerifierMessageBase;
 import org.emla.dbcomponent.Dataset;
 import org.emla.learning.Frequency;
 import org.emla.learning.FrequencyTable;
@@ -9,6 +16,7 @@ import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.utils.KieHelper;
 
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -61,6 +69,31 @@ public class DroolsAgentApp {
     }
 
     public DrlAssessment evaluateAgentRequests(){
+        Verifier verifier = VerifierBuilderFactory.newVerifierBuilder().newVerifier();
+        verifier.addResourcesToVerify(new ReaderResource(new StringReader(DRL)), ResourceType.DRL);
+        verifier.fireAnalysis();
+        VerifierReport result = verifier.getResult();
+
+        System.out.println("===== NOTES =====");
+        for (VerifierMessageBase message : result.getBySeverity(Severity.NOTE)) {
+            System.out.println(message);
+        }
+
+        System.out.println("===== WARNS =====");
+        for (VerifierMessageBase message : result.getBySeverity(Severity.WARNING)) {
+            System.out.println(message);
+        }
+
+        System.out.println("===== ERRORS =====");
+        for (VerifierMessageBase message : result.getBySeverity(Severity.ERROR)) {
+            System.out.println(message);
+        }
+
+        System.out.println("===== GAPS =====");
+        for (MissingRange message : result.getRangeCheckCauses()) {
+            System.out.println(message);
+        }
+
         KieSession kieSession = kieBase.newKieSession();
         allow = new ArrayList<>();
         kieSession.setGlobal("allow", allow);

--- a/src/main/java/org/nprentza/DroolsAgentApp.java
+++ b/src/main/java/org/nprentza/DroolsAgentApp.java
@@ -33,7 +33,7 @@ public class DroolsAgentApp {
 
     public DroolsAgentApp(){
         //kieBase = new KieHelper().addFromClassPath("/dataAccess.drl").build(ExecutableModelProject.class);
-        kieBase = new KieHelper().addContent(DRL, ResourceType.DRL).build(ExecutableModelProject.class);
+        kieBase = new KieHelper().addContent(DRL, "org/nprentza/dataAccess.drl").build(ExecutableModelProject.class);
     }
 
     public void updateDrl(List<FrequencyTable> frequencyTables, Frequency bestFrequency){

--- a/src/main/resources/dataAccess.drl
+++ b/src/main/resources/dataAccess.drl
@@ -1,19 +1,20 @@
 package org.nprentza;
 
-import org.nprentza.Agent
+import org.nprentza.Agent;
+import org.nprentza.AgentRole;
 
 global java.util.List allow;
 global java.util.List deny;
 
-rule AllowAdmin when
-	$a: Agent( role == "admin" )
+rule 'AllowAdmin' when
+	$a: Agent( role == AgentRole.ADMIN )
 then
     $a.setGrantAccess( true );
 	allow.add( $a.getId() );
 end
 
-rule DenyGuest when
-	$a: Agent( role == "guest" )
+rule 'DenyGuest' when
+	$a: Agent( role == AgentRole.GUEST )
 then
     $a.setGrantAccess( false );
 	deny.add( $a.getId() );

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration>
+  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+  <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+  <appender name="STDOUT" class="ConsoleAppender">
+    <encoder class="PatternLayoutEncoder">
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.drools" level="info"/>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>

--- a/src/test/java/org/nprentza/DrlConverterTest.java
+++ b/src/test/java/org/nprentza/DrlConverterTest.java
@@ -1,0 +1,17 @@
+package org.nprentza;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+import org.junit.jupiter.api.Test;
+
+class DrlConverterTest {
+
+    @Test
+    void outputMatchesSampleDrlFile() {
+        String drl = DrlConverter.preamble()
+                + DrlConverter.rule("AllowAdmin", "role", "admin", "allow")
+                + DrlConverter.rule("DenyGuest", "role", "guest", "deny");
+        assertThat(drl).isEqualToIgnoringWhitespace(contentOf(DrlConverterTest.class.getResource("/dataAccess.drl")));
+    }
+}


### PR DESCRIPTION
It doesn't seem the analysis can be used to detect gaps in rules that compare the `role` field of String/enum type. Main output:
```
14:27:55.511 [main] INFO  o.d.c.k.b.impl.KieContainerImpl -- Start creation of KieBase: defaultKieBase
14:27:55.621 [main] INFO  o.d.c.k.b.impl.KieContainerImpl -- End creation of KieBase: defaultKieBase
===== NOTES =====
===== WARNS =====
Warning id = 0:
faulty : LiteralRestriction from rule [AllowAdmin] value '== AgentRole.ADMIN'
Rule base covers == AgentRole.ADMIN, but it is missing != AgentRole.ADMIN 
	Cause trace: 

Warning id = 1:
faulty : LiteralRestriction from rule [DenyGuest] value '== AgentRole.GUEST'
Rule base covers == AgentRole.GUEST, but it is missing != AgentRole.GUEST 
	Cause trace: 

===== ERRORS =====
===== GAPS =====
Validating a DRL against a set of data.
Data cases [3, 6] are not covered by the DRL. 
We will use the OneR algorithm to find additional rules for these cases.

Frequency Table for predictor 'role':

>> for role=contributor (Coverage= 1 )  (Best target value = allow, with error=0 )  ) :
	[allow, 2]

Frequency Table for predictor 'experience':

>> for experience=junior (Coverage= 0.5 )  (Best target value = allow, with error=0 )  ) :
	[allow, 1]

Update DRL with the *best* frequency selected:
>> for role=contributor (Coverage= 1 )  (Best target value = allow, with error=0 )  ) :
	[allow, 2]
14:27:59.138 [main] WARN  o.d.c.k.builder.impl.KieBuilderImpl -- File 'file0.drl' is in folder '' but declares package 'org.nprentza'. It is advised to have a correspondance between package and folder names.
14:27:59.313 [main] INFO  o.d.c.k.b.impl.KieContainerImpl -- Start creation of KieBase: defaultKieBase
14:27:59.321 [main] INFO  o.d.c.k.b.impl.KieContainerImpl -- End creation of KieBase: defaultKieBase

Re-evaluate the DRL.
===== NOTES =====
===== WARNS =====
Warning id = 2:
faulty : LiteralRestriction from rule [AllowAdmin] value '== AgentRole.ADMIN'
Rule base covers == AgentRole.ADMIN, but it is missing != AgentRole.ADMIN 
	Cause trace: 

Warning id = 3:
faulty : LiteralRestriction from rule [DenyGuest] value '== AgentRole.GUEST'
Rule base covers == AgentRole.GUEST, but it is missing != AgentRole.GUEST 
	Cause trace: 

Warning id = 4:
faulty : LiteralRestriction from rule [allowcontributor] value '== AgentRole.CONTRIBUTOR'
Rule base covers == AgentRole.CONTRIBUTOR, but it is missing != AgentRole.CONTRIBUTOR 
	Cause trace: 

===== ERRORS =====
===== GAPS =====
The revised DRL covers all data cases.

Process finished with exit code 0
```

Warnings 0 and 1 report that there are rules that check for `== ADMIN` and `== GUEST` and we're missing rules that check for `!= ADMIN` and `!= GUEST`. That doesn't seem very useful. What I would expect, in the case of an enum field, is a message that tells me I'm missing a rule that checks for `== CONTRIBUTOR`.